### PR TITLE
Use pthread explicitly; needed for Ubuntu 11.04

### DIFF
--- a/ext/phashion_ext/extconf.rb
+++ b/ext/phashion_ext/extconf.rb
@@ -39,7 +39,7 @@ Dir.chdir(HERE) do
     system("cp -f libpHash.a libpHash_gem.a")
     system("cp -f libpHash.la libpHash_gem.la")
   end
-  $LIBS = " -lpHash_gem -lstdc++ -ljpeg"
+  $LIBS = " -lpthread -lpHash_gem -lstdc++ -ljpeg"
 end
 
 create_makefile 'phashion_ext'


### PR DESCRIPTION
I was unable to install the phashion gem on Ubuntu 11.04. The problem was that the pthread library was not used. 

This pull requests includes pthread and thus enables installation on Ubuntu 11.04. 

Have fun!

/Ariejan
