### PR TITLE
Unable to install on ubuntu 11.11

### DIFF
--- a/ext/phashion_ext/extconf.rb
+++ b/ext/phashion_ext/extconf.rb
@@ -19,7 +19,7 @@ Dir.chdir(HERE) do
     raise "'#{cmd}' failed" unless system(cmd)
 
     Dir.chdir(BUNDLE_PATH) do
-      puts(cmd = "env CFLAGS='#{$CFLAGS}' LDFLAGS='#{$LDFLAGS}' ./configure --prefix=#{HERE} --disable-audio-hash --disable-video-hash --disable-shared --with-pic 2>&1")
+      puts(cmd = "env CFLAGS='#{$CFLAGS}' LDFLAGS='#{$LDFLAGS}' ./configure --prefix=#{HERE} --disable-audio-hash --disable-video-hash --disable-pthread --disable-shared --with-pic 2>&1")
       raise "'#{cmd}' failed" unless system(cmd)
 
       puts(cmd = "make || true 2>&1")


### PR DESCRIPTION
I got it to compile on OSX for my dev environment but I'm having issues on linux.

I have libjpeg8-dev installed, but the file missing seems to be part of the phash library somehow.

Also those error in the examples seem odd, looks like -lpthread is missing there.

```
make[1]: Entering directory `/var/lib/gems/1.9.1/gems/phashion-1.0.4/ext/phashion_ext/pHash-0.9.3/examples'
/bin/bash ../libtool --tag=CXX   --mode=link g++  -O2 -ffast-math -O3  -L/usr/local/lib -ljpeg -o buildmvptreedct buildmvptree_dctimage.o ../src/libpHash.la -lm  
libtool: link: g++ -O2 -ffast-math -O3 -o buildmvptreedct buildmvptree_dctimage.o  -L/usr/local/lib ../src/.libs/libpHash.a -ljpeg -lm
../src/.libs/libpHash.a(pHash.o): In function `ph_dct_image_hashes':
pHash.cpp:(.text+0x19ee): undefined reference to `pthread_create'
pHash.cpp:(.text+0x1a07): undefined reference to `pthread_join'
collect2: ld returned 1 exit status
make[1]: *** [buildmvptreedct] Error 1
make[1]: Leaving directory `/var/lib/gems/1.9.1/gems/phashion-1.0.4/ext/phashion_ext/pHash-0.9.3/examples'
make: *** [install-recursive] Error 1
mv CImg.h ../include 2>&1
creating Makefile

make
gcc -I. -I/usr/include/ruby-1.9.1/x86_64-linux -I/usr/include/ruby-1.9.1/ruby/backward -I/usr/include/ruby-1.9.1 -I.   -fPIC  -I/var/lib/gems/1.9.1/gems/phashion-1.0.4/ext/phashion_ext/include  -L/var/lib/gems/1.9.1/gems/phashion-1.0.4/ext/phashion_ext/lib  -x c++   -o phashion_ext.o -c phashion_ext.c
In file included from phashion_ext.c:2:0:
/var/lib/gems/1.9.1/gems/phashion-1.0.4/ext/phashion_ext/include/pHash.h:31:26: fatal error: pHash-config.h: No such file or directory
compilation terminated.
make: *** [phashion_ext.o] Error 1
```
