### PR TITLE
unlock the GVL while calculating a hash

### DIFF
--- a/ext/phashion_ext/phashion_ext.c
+++ b/ext/phashion_ext/phashion_ext.c
@@ -1,13 +1,47 @@
 #include "ruby.h"
 #include "pHash.h"
+#ifdef HAVE_RUBY_THREAD_H
+#include <ruby/thread.h>
+#else
+#include <ruby/intern.h>
+void *
+rb_thread_call_without_gvl(void *(*func)(void *data), void *data1,
+			    rb_unblock_function_t *ubf, void *data2) {
+  return (void *)rb_thread_blocking_region(
+      (rb_blocking_function_t *)func, data1,
+      (rb_unblock_function_t *)ubf, data2);
+}
+#endif
+
+struct nogvl_hash_args {
+  const char * filename;
+  ulong64 hash;
+  int retval;
+};
+
+static void * nogvl_hash(struct nogvl_hash_args * args) {
+  ulong64 hash;
+
+  args->retval = ph_dct_imagehash(args->filename, hash);
+  args->hash = hash;
+
+  return NULL;
+}
 
 static VALUE image_hash_for(VALUE self, VALUE _filename) {
-    char * filename = StringValuePtr(_filename);
     ulong64 hash;
-    if (-1 == ph_dct_imagehash(filename, hash)) {
+    struct nogvl_hash_args args;
+
+    args.filename = StringValuePtr(_filename);
+    args.retval = -1;
+
+    rb_thread_call_without_gvl((void *(*)(void *))nogvl_hash,
+        (void *)&args, RUBY_UBF_PROCESS, 0);
+
+    if (-1 == args.retval) {
       rb_raise(rb_eRuntimeError, "Unknown pHash error");
     }
-    return ULL2NUM(hash);
+    return ULL2NUM(args.hash);
 }
 
 


### PR DESCRIPTION
Hi,

I need to calculate the hashes for many images.  This patch unlocks the GVL around hash calculation so that I can do hash calculations in parallel.

Here is a demo program:

``` ruby
require 'phashion'
require 'find'
require 'thread'

queue = Queue.new

Find.find(ARGV[0]) do |f|
  next if File.directory? f
  queue << f if f =~ /jpg$/
end

threads = 4.times.map {
  Thread.new {
    while filename = queue.pop
      Phashion.image_hash_for filename
    end
  }
}

4.times { queue << nil }
threads.each(&:join)
```

Here is CPU utilization before my patch:

![cpu utilization](https://dl.dropbox.com/s/p6aoyophvpa30v4/Activity_Monitor_All_Processes_20131208_183013.jpg)

Here is the CPU utilization after my patch is applied:

![cpu utilization2](https://dl.dropbox.com/s/cyrky5r8p06s460/Activity_Monitor_All_Processes_20131208_183152.jpg)
