### PR TITLE
ignore generic ruby files:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,9 @@ coverage
 rdoc
 pkg
 *.gem
+.ruby-version
+.ruby-gemset
+Gemfile.lock
+tmp
 
 ## PROJECT::SPECIFIC


### PR DESCRIPTION
- Gemfile.lock - all dependencies should be locked in gemspec
- .ruby-version - all ruby dependencies should be set in gemspec
- .ruby-gemset - project should be gemset independent
- tmp only use during compiling. by definition, not important
