### PR TITLE
added optional positional initializers for @hash and @mh_hash to constructor

### DIFF
--- a/lib/phashion.rb
+++ b/lib/phashion.rb
@@ -16,8 +16,11 @@ module Phashion
     DEFAULT_DUPE_THRESHOLD = 15
  
     attr_reader :filename
-    def initialize(filename)
+
+    def initialize(filename, my_hash=nil, my_mh_hash=nil)
       @filename = filename
+      @hash     = my_hash
+      @mh_hash  = my_mh_hash
     end
 
     # returns: an Integer representing the hamming distance from :other


### PR DESCRIPTION
This change is to the Image class constructor method.  It has no impact to existing tests or to the C extension.  This form of the constructor is a little more flexible in that applications which have existing fingerprints for an image can create an Image instance without having to redo the fingerprints.


