### PR TITLE
Add meta methods: dupe_at_threshold_<n>?

### DIFF
--- a/lib/phashion.rb
+++ b/lib/phashion.rb
@@ -35,6 +35,10 @@ module Phashion
       distance_from(other) <= threshold
     end
 
+    (0..64).each do |n|
+      define_method("dupe_at_threshold_#{n}?") { |oth| distance_from(oth) <= n }
+    end
+
     def fingerprint
       @hash ||= Phashion.image_hash_for(@filename)
     end

--- a/test/test_phashion.rb
+++ b/test/test_phashion.rb
@@ -149,6 +149,17 @@ class TestPhashion < Minitest::Test
     assert(jpg.duplicate?(jpg_x, threshold: 2))
   end
 
+   def test_duplicate_meta_methods
+    # note: this test depends on the smaller_jpg test still asserting a distance of 2
+    # note-2: threshold is a :less-than-or-equal-to comparison, which is a change from version 1.0.8
+    jpg = Phashion::Image.new(File.dirname(__FILE__) + '/jpg/Broccoli_Super_Food.jpg')
+    jpg_x = Phashion::Image.new(File.dirname(__FILE__) + '/jpg/Broccoli_Super_Food.100px.jpg')
+
+    refute(jpg.dupe_at_threshold_1?(jpg_x))
+    assert(jpg.dupe_at_threshold_2?(jpg_x))
+    assert_raises NoMethodError { jpg.dupe_at_threshold_100?(jpg_x) }
+  end
+
 
   ### distance methods
   def test_distance_from_jpg_to_png_dupe

--- a/test/test_phashion.rb
+++ b/test/test_phashion.rb
@@ -157,7 +157,7 @@ class TestPhashion < Minitest::Test
 
     refute(jpg.dupe_at_threshold_1?(jpg_x))
     assert(jpg.dupe_at_threshold_2?(jpg_x))
-    assert_raises NoMethodError { jpg.dupe_at_threshold_100?(jpg_x) }
+    assert_raises(NoMethodError) { jpg.dupe_at_threshold_100?(jpg_x) }
   end
 
 


### PR DESCRIPTION
In my problem domain (& I guess many others) I am happy with a set custom threshold and do not need to change it in every `#duplicate?` method call. I've therefore added a set of 'duplicate' methods with fixed, custom thresholds, created at require time. In testing with a cross comparison of around 10,000 images for duplicates, using one of the meta methods (e.g. `#dupe_at_threshold_7?`) gave a 40% + performance improvement vs. using `#duplicate?` which reads from a threshold parameter on each call.