### PR TITLE
Add -lmvec to to fix undefined symbol on Ubuntu 18

### DIFF
--- a/ext/phashion_ext/extconf.rb
+++ b/ext/phashion_ext/extconf.rb
@@ -40,7 +40,7 @@ Dir.chdir(HERE) do
     system("cp -f libpHash.a libpHash_gem.a")
     system("cp -f libpHash.la libpHash_gem.la")
   end
-  $LIBS = " -lpthread -lpHash_gem -lstdc++ -ljpeg -lpng"
+  $LIBS = " -lpthread -lpHash_gem -lstdc++ -ljpeg -lpng -lmvec"
 end
 
 have_header 'sqlite3ext.h'


### PR DESCRIPTION
In the process of updating a container from Ubuntu 16.04 base to Ubuntu 18.04 base, I ran into the following error when trying to require the `phashion` gem:

```
`require': /tmp/phashion/lib/phashion_ext.so: undefined symbol: _ZGVbN2v_cos - /tmp/phashion/lib/phashion_ext.so (LoadError)
```

Adding libmvec to the dependency list fixed this issue, and did not cause any issues on Ubuntu 16.