### PR TITLE
chore: Add Ruby 3.1 and 3.2 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.2, 3.1, 3.0, 2.7, 2.6, 2.5]
+        ruby-version: [3.2, 3.1, 3.0, 2.7]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
@westonplatter Removed anything older than 2.7, as those versions are EOL.