### PR TITLE
Fix installation failure for Ruby 3.1 and 3.2 on Mac OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.0, 2.7, 2.6, 2.5]
+        ruby-version: [3.2, 3.1, 3.0, 2.7, 2.6, 2.5]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install xmllint

--- a/ext/phashion_ext/extconf.rb
+++ b/ext/phashion_ext/extconf.rb
@@ -4,6 +4,7 @@ HERE = File.expand_path(File.dirname(__FILE__))
 BUNDLE = Dir.glob("#{HERE}/pHash-*.tar.gz").first
 BUNDLE_PATH = BUNDLE.gsub(".tar.gz", "")
 $CFLAGS = " -x c++ #{ENV["CFLAGS"]}"
+$CFLAGS += " -fdeclspec" if RUBY_PLATFORM =~ /darwin/
 $includes = " -I#{HERE}/include"
 $libraries = " -L#{HERE}/lib -L/usr/local/lib"
 $LIBPATH = ["#{HERE}/lib"]

--- a/ext/phashion_ext/extconf.rb
+++ b/ext/phashion_ext/extconf.rb
@@ -40,7 +40,7 @@ Dir.chdir(HERE) do
     system("cp -f libpHash.a libpHash_gem.a")
     system("cp -f libpHash.la libpHash_gem.la")
   end
-  $LIBS = " -lpthread -lpHash_gem -lstdc++ -ljpeg -lpng"
+  $LIBS = " -lpthread -lpHash_gem -lstdc++ -ljpeg -lpng -lm"
 end
 
 have_header 'sqlite3ext.h'


### PR DESCRIPTION
Updated extcnof to add `-fdeclspec` cflag on Mac OS build.