### PR TITLE
macOS fix for sqlite3ext.h

### DIFF
--- a/ext/phashion_ext/extconf.rb
+++ b/ext/phashion_ext/extconf.rb
@@ -41,8 +41,15 @@ Dir.chdir(HERE) do
     system("cp -f libpHash.a libpHash_gem.a")
     system("cp -f libpHash.la libpHash_gem.la")
   end
-  $LIBS = " -lpthread -lpHash_gem -lstdc++ -ljpeg -lpng -lm"
+
 end
+
+$CFLAGS += " #{(Array pkg_config "libjpeg").join " "}"
+raise "missing jpeglib.h" unless have_header("jpeglib.h")
+$CFLAGS += " #{(Array pkg_config "libpng").join " "}"
+raise "missing png.h" unless have_header("png.h")
+
+$LIBS = " -lpthread -lpHash_gem -lstdc++ -ljpeg -lpng -lm"
 
 have_header 'sqlite3ext.h'
 


### PR DESCRIPTION
This might resolve #97 and #44.
1. it does not blame the sqlite anymore but correctly points at jpeg and png libraries
2. if you already have them installed it does not fail to locate them