### PR TITLE
fix minitest mutex_m LoadError in 3.4; drop EOL Rubies from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.2, 3.1, 3.0, 2.7]
+        ruby-version: [3.4, 3.3, 3.2]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/phashion.gemspec
+++ b/phashion.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency "rake-compiler", ">= 0.7.0"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "minitest", "~> 5.2.2"
+  s.add_development_dependency "minitest", ">= 5.21.0"
 end
-


### PR DESCRIPTION
Minitest > 5.21 required in Ruby 3.4 to avoid `cannot load such file -- mutex_m (LoadError)` see this [commit](https://github.com/minitest/minitest/commit/5f5c2111f36658fd2636b108b8327ce4b2f3cf8d)

Ruby 2.7, 3.0 and 3.1 are EOL